### PR TITLE
DTSW-2814 porting docs units C12 C13

### DIFF
--- a/src/_images/duckiebot_assembly_and_setup/calibration_camera/a3-calibraion-pattern.png
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_camera/a3-calibraion-pattern.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4752eff89b016f04186e5f2e22294ef3110da3cce9761d803e951c10277a58cc
+size 92535

--- a/src/_images/duckiebot_assembly_and_setup/calibration_camera/extrinsic_setup.jpg
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_camera/extrinsic_setup.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef76b77481922787a0c4c4fb7418cd4528c76d307e970e135dbd000b5a74a882
+size 1211589

--- a/src/_images/duckiebot_assembly_and_setup/calibration_camera/extrinsic_view.jpg
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_camera/extrinsic_view.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd03f6ad015850827cec8bde65449b3a6780b94fa5ba3f758ff6512e72d82cd7
+size 2312979

--- a/src/_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_calibratestep.png
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_calibratestep.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd9a36ef29dab2a708db1bc01786a6cd93a1277c188c6f713cfc1d57f16a580d
+size 276364

--- a/src/_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_commit.png
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_commit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a98c28f8e0a101e5945e95787ca9317f008d13729ebd1fffb9fd1d03c518bb70
+size 236474

--- a/src/_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_pre.png
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_pre.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6dc4d99415d015d869ea41016b1e0230d9edf04f604313218f7b21d1e1da5b7
+size 270873

--- a/src/_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_line.jpg
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_line.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52b55b0752e662f8ea7fbfd06c0a4cd498f6435c9e082332ab144ba6df8bc201
+size 1363273

--- a/src/_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_lr_drift.jpg
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_lr_drift.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6bad8b76392b842d1621a776798869e87d08ad66804372ea2396e56f652bef3
+size 857516

--- a/src/_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_measuring_drift.jpg
+++ b/src/_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_measuring_drift.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df007242da6cfb0a019c0c79799960296af8959a681bbb6f575fa443cca1faf4
+size 4588330

--- a/src/_toc.yml
+++ b/src/_toc.yml
@@ -23,3 +23,9 @@ parts:
             sections:
                 - file: part_2/chapter_c/section_1
                 - file: part_2/chapter_c/section_2
+    - caption: Duckiebot Assembly and Setup
+      maxdepth: 2
+      numbered: False
+      chapters:
+          - file: duckiebot_assembly_and_setup/calibration_camera/index
+

--- a/src/_toc.yml
+++ b/src/_toc.yml
@@ -28,4 +28,5 @@ parts:
       numbered: False
       chapters:
           - file: duckiebot_assembly_and_setup/calibration_camera/index
+          - file: duckiebot_assembly_and_setup/calibration_wheels/index
 

--- a/src/duckiebot_assembly_and_setup/calibration_camera/index.md
+++ b/src/duckiebot_assembly_and_setup/calibration_camera/index.md
@@ -1,0 +1,191 @@
+(camera-calib)=
+# Calibration - Camera
+
+This section describes the intrinsic and extrinsic calibration procedures.
+
+```{needget}
+You can see the camera image on the laptop.
+---
+That your camera intrinsics and extrinsics are calibrated and stored on the Duckiebot.
+```
+
+(camera-calibration-pattern-materials)=
+## Materials
+
+### Calibration board
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_camera/a3-calibraion-pattern.png
+:width: 20em
+:name: fig:calibration_checkerboard
+
+Calibration checkerboard
+```
+
+If you do not have one already:
+
+* Download the [Calibration checkerboard pdf](https://github.com/duckietown/duckietown-mplan/blob/a025c99e218687685d80bd72a7f90996572a55c7/hardware/camera_calibration_pattern_A3.pdf)
+* Print it with ***A3 Format***
+* Fix the checkerboard to a rigid planar surface that you can move around
+
+
+```{note}
+* The squares must have side equal to 0.031 m = 3.1 cm. Please measure this, as having the wrong size will make your Duckiebot crash.
+* In case your squares are not of the right size, make sure your printer settings are on A3 format, no automatic scaling, 100% size.
+```
+
+```{warning}
+If the pattern is not rigid the calibration will be useless. You can print on thick paper or adhere to something rigid to achieve this.
+```
+
+
+### Optional material
+
+This is not necessary, but you could also use a "lane" during the extrinsic calibration procedure.
+
+
+## Intrinsic Calibration
+
+Every camera is a little bit different, so we need to do a camera calibration procedure to account for the small manufacturing discrepancies.
+This process will involve displaying a predetermined pattern to the camera, and using it to solve for the camera parameters.
+For more information, see [our theory slides](https://github.com/duckietown/lectures/blob/master/1_ideal/25_computer_vision/cv_calibration.pdf).
+And the procedure is basically a wrapper around the [ROS camera calibration tool](http://wiki.ros.org/camera_calibration).
+
+### Launch the intrinsic calibration application
+
+Next you can launch the intrinsic calibration program with:
+
+```
+dts duckiebot calibrate_intrinsics [your_duckiebot_hostname]
+```
+
+You should see an application launching, similar to the following figure, on the laptop.
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_pre.png
+:width: 30em
+:name: fig:intrinsic_callibration_pre
+
+Intrinsic camera calibration tool
+```
+
+```{trouble}
+Only a black window starts up
+---
+Try resizing the window manually once using cursor, and you should see the window content correctly.
+```
+
+### Calibration dance
+
+Position the checkerboard in front of the camera until you see colored lines overlaying the checkerboard.
+You will only see the colored lines if the **entire** checkerboard is within the field of view of the camera.
+
+You should also see colored bars in the sidebar of the display window.
+These bars indicate the current range of the checkerboard in the camera's field of view:
+
+- X bar: the observed horizontal range (left - right)
+- Y bar: the observed vertical range (top - bottom)
+- Size bar: the observed range in the checkerboard size (forward - backward from the camera direction)
+- Skew bar: the relative tilt between the checkerboard and the camera direction
+
+Also, make sure to focus the image by rotating the mechanical focus ring on the lens of the camera.
+
+```{warning}
+Do not touch the focus anymore, ever, as it will invalidate calibration.
+```
+
+Now move the checkerboard right/left, up/down, and tilt the checkerboard
+through various angles of relative to the image plane. After each movement,
+make sure to pause long enough for the checkerboard to become highlighted. Once
+you have collected enough data, all four indicator bars will turn green. Press
+the "CALIBRATE" button in the sidebar.
+
+Calibration may take a few moments. Note that the screen may dim. Don't worry, the calibration is working.
+
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_calibratestep.png
+:width: 30em
+:name: fig:intrinsic_calibration_calibratestep
+
+Calibration step
+```
+
+
+### Save the calibration results
+
+If you are satisfied with the calibration, you can save the results by pressing the "COMMIT" button in the side bar. (You never need to click the "SAVE" button.)
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_camera/intrinsic_calibration_commit.png
+:width: 30em
+:name: fig:intrinsic_calibration_commit
+
+Committing the calibration
+```
+
+This will automatically save the calibration results on your Duckiebot:
+
+```
+/data/config/calibrations/camera_intrinsic/[your_duckiebot_hostname].yaml
+```
+
+You can view or download the calibration file using the Dashboard running at `http://[your_duckiebot_hostname].local` under `File Manager` in the sidebar on the left, navigating to `config/calibrations/camera_intrinsic/`.
+
+
+### Keeping your calibration valid
+
+```{warning}
+* Do not change the focus during or after the calibration, otherwise your calibration is no longer valid.
+* Do not use the lens cover anymore; removing the lens cover may change the focus.
+```
+
+(extrinsic-camera-calibration)=
+## Extrinsic Camera Calibration
+
+(camera-calib-jan18-extrinsics-setup)=
+### Setup
+
+Arrange the Duckiebot and checkerboard according to {numref}`fig:extrinsic_setup2`. Note that the axis of the wheels should be aligned with the y-axis.
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_camera/extrinsic_setup.jpg
+:width: 30em
+:name: fig:extrinsic_setup2
+
+Extrinsic calibration setup
+```
+
+{numref}`fig:extrinsic_view2` shows a view of the calibration checkerboard from the Duckiebot. To ensure proper calibration there should be no clutter in the background.
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_camera/extrinsic_view.jpg
+:width: 30em
+:name: fig:extrinsic_view2
+
+Extrinsic calibration view
+```
+
+
+### Launch the extrinsic calibration pipeline
+
+Run:
+
+```
+dts duckiebot calibrate_extrinsics [your_duckiebot_hostname]
+```
+
+First the output will instruct you place your robot on the calibration box and press <kbd>Enter</kbd>.
+If all goes well the program will complete.
+
+And this will automatically save the calibration results on your Duckiebot:
+
+```
+/data/config/calibrations/camera_extrinsic/[your_duckiebot_hostname].yaml
+```
+
+
+Similar to intrinsic calibration, you can also view or download the calibration file using the Dashboard.
+
+
+#### Troubleshooting
+
+```{trouble}
+You see a long complicated error message that ends with something about `findChessBoardCorners failed`.
+---
+Your camera is not viewing the full checkerboard pattern. Most likely part of the chess board pattern is occluded. Possibly you didn't assemble your Duckiebot correctly or you did not put it on the calibration pattern properly.
+```

--- a/src/duckiebot_assembly_and_setup/calibration_wheels/index.md
+++ b/src/duckiebot_assembly_and_setup/calibration_wheels/index.md
@@ -1,0 +1,156 @@
+(wheel-calibration)=
+# Calibration - Wheels
+
+```{needget}
+You can make your robot move
+---
+You can calibrate the wheels of the Duckiebot such that it goes in a straight line
+when commanded so. You can set the maximum speed of the Duckiebot.
+```
+
+:::{note}
+In the following documentation on this page, `[hostname]` refers to the hostname of your duckiebot. For example:
+
+```
+ping [hostname].local
+```
+
+with a Duckiebot named `myrobot` would be:
+
+```
+ping myrobot.local
+```
+
+Also, replace other fields in a command with `[]` around with the corresponding values.
+
+:::
+
+## Step 1: Make your robot move
+
+Follow instructions in [TODO](sec:rc-control) to make your robot move with keyboard control, and keep the terminal open. 
+
+## Step 2: See how the robot really moves
+
+There is a lot going on between pressing <kbd>&#x21e7;</kbd> (up arrow) on the keyboard and your Duckiebot moving. To get a better view of what is going on, we need another terminal, but ran closer to where the action is happening:
+
+```
+dts start_gui_tools [hostname]
+```
+
+Duckietown uses [ROS](https://www.ros.org/) to move data around. To determine if the command above worked, type:
+
+```
+rostopic list
+```
+
+You should see a list of ROS _topics_ currently active on your Duckiebot. If you know ROS, here you can use ROS commands at will. If you are not familiar with ROS, note that each of these _topics_ might carry _messages_, i.e., actual data. You can, e.g., "listen" to the data inside each topic. For example:
+
+
+```
+rostopic echo /[hostname]/camera_node/image/compressed
+```
+
+will show you incoming images as the Duckiebot sees them! You won't be able to read bytes or make sense of pixel values, though. Now, press `Ctrl+C` to stop reading the camera stream.
+
+:::{note}
+Keep this terminal open. We will use it to perform the wheel calibration. All the `ros...` commands below are executed in such a terminal.
+:::
+
+## Step 3: Perform the calibration
+
+### Calibrating the `trim` parameter
+
+The trim parameter is set to $0.00$ by default, under the assumption that both motors and wheels are perfectly identical. You can change the value of the trim parameter by running the command (in the `start_gui_tools` terminal from the previous step):
+
+```
+rosparam set /[hostname]/kinematics_node/trim [trim_value]
+```
+
+Use some tape to create a straight line on the floor ({numref}`fig:wheel_calibration_line`).
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_line.jpg
+:width: 30em
+:name: fig:wheel_calibration_line
+
+Straight line useful for wheel calibration
+```
+
+Place your Duckiebot on one end of the tape.
+Make sure that the Duckiebot is perfectly centered with respect to the line.
+
+Command your Duckiebot to go straight for about 2 meters.
+Observe the Duckiebot from the point where it started moving,
+and annotate on which side of the tape the Duckiebot drifted ({numref}`fig:wheel_calibration_lr_drift`).
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_lr_drift.jpg
+:width: 30em
+:name: fig:wheel_calibration_lr_drift
+
+Left/Right drift
+```
+
+Measure the distance between the center of the tape and the center of the axle of
+the Duckiebot after it traveled for about 2 meters ({numref}`fig:wheel_calibration_measuring_drift`).
+
+Make sure that the ruler is orthogonal to the tape.
+
+```{figure} ../../_images/duckiebot_assembly_and_setup/calibration_wheels/wheel_calibration_measuring_drift.jpg
+:width: 30em
+:name: fig:wheel_calibration_measuring_drift
+
+Measure the amount of drift after 2 meters run
+```
+
+If the Duckiebot drifted by less than $10$ centimeters you can stop calibrating the trim parameter.
+A drift of $10$ centimeters in a $2$ meters run is good enough for Duckietown.
+If the Duckiebot drifted by more than $10$ centimeters, continue with the next step.
+
+If the Duckiebot drifted to the left side of the tape, decrease the value of $r$, by running, for example:
+
+```
+rosparam set /[hostname]/kinematics_node/trim -0.1
+```
+
+If the Duckiebot drifted to the right side of the tape, increase the value of $r$, by running, for example:
+
+```
+rosparam set /[hostname]/kinematics_node/trim 0.1
+```
+
+Repeat this process until the robot drives straight.
+
+
+### Calibrating the `gain` parameter
+
+The gain parameter is set to $1.00$ by default. You can change its value by
+running the command:
+
+```
+rosparam set /[hostname]/kinematics_node/gain [gain_value]
+```
+
+### Store the calibration
+
+When you are all done, save the parameters by running:
+
+```
+rosservice call /[hostname]/kinematics_node/save_calibration
+```
+
+The first time you save the parameters, this command will create the calibration file
+
+
+### Final check to make sure it's stored
+
+The calibration result is saved on your Duckiebot:
+
+```
+/data/config/calibrations/kinematics/[hostname].yaml
+```
+
+You can view or download the calibration file using the Dashboard running at `http://[hostname].local` under `File Manager` in the sidebar on the left, navigating to `config/calibrations/kinematics/`.
+
+
+### Additional information
+
+There are additional parameters you can to play around with to get a better driving experience. You can learn about odometry and odometry calibration here: [video](https://vimeo.com/manage/videos/580764763), [theory, activities and exercises](https://github.com/duckietown/mooc-exercises/tree/daffy/modcon).


### PR DESCRIPTION
Following sections are taken from the old docs to jupyter book docs
* Unit-C12: Camera calibration
* Unit-C13: Wheels calibration

The relevant `_toc.yml` changes:
![image](https://user-images.githubusercontent.com/10885835/223857969-478d1fbb-f972-4d9b-87e8-5dfaad6174d6.png)

The compiled camera calibration doc:
![book-opmanual-duckiebot_html_duckiebot_assembly_and_setup_calibration_camera_index html](https://user-images.githubusercontent.com/10885835/223858079-2978d33a-4eeb-4999-9ac4-19cbdc650aef.png)

The compiled wheels calibration doc:
![book-opmanual-duckiebot_html_duckiebot_assembly_and_setup_calibration_wheels_index html](https://user-images.githubusercontent.com/10885835/223858116-11faa68d-f985-401c-89c7-d522232c2e58.png)
