### PR TITLE
Adds instructions for adding dts to the PATH for Linux

### DIFF
--- a/src/setup/setup_laptop/setup_dt_shell.md
+++ b/src/setup/setup_laptop/setup_dt_shell.md
@@ -20,6 +20,21 @@ Install the Duckietown Shell using the following command,
 
     pip3 install --no-cache-dir --user --upgrade duckietown-shell
 
+
+**2) Source dts**
+
+Make sure your system is able to find local binaries by adding the following to your `.bashrc` file. 
+
+```{attention}
+If you are using `zsh`, replace the `.bashrc` in the commands below with `.zshrc` instead.
+```
+
+    export PATH=~/.local/bin:${PATH}
+
+Then source the updates to your current shell or restart your shell.
+
+    source ~/.bashrc
+
 ---
 
 **Checkpoint ✅**


### PR DESCRIPTION
I've found that by default, the Duckietown shell may not be added to the PATH on Linux. While many people will know what to do in this situation, it should still be explained, especially for newcomers to programming who may not have had to deal with the command line before.