### PR TITLE
Add rqt_image_view save image instructions

### DIFF
--- a/src/_images/operations/rqt_image_view_save_btn.png
+++ b/src/_images/operations/rqt_image_view_save_btn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86b8baaadb33b55c1d1b7d58222ec98909f33e092c38279ab7681b3bb38b787f
+size 8528

--- a/src/_images/operations/rqt_image_view_save_dialog1.png
+++ b/src/_images/operations/rqt_image_view_save_dialog1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08e5ab3c26a4ed5f4bb71f0c0c83c2c18fa2fe868e9fef303241ca9df12818bc
+size 16799

--- a/src/_images/operations/rqt_image_view_save_dialog2.png
+++ b/src/_images/operations/rqt_image_view_save_dialog2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f80a4165fa81e3ced14a8002cb1d79aa8e51642a871f0519280e3e3ea1ada069
+size 37537

--- a/src/operations/make_it_see/index.md
+++ b/src/operations/make_it_see/index.md
@@ -33,6 +33,41 @@ You will have to select the `camera_node/image/compressed` topic from the drop-d
 The rqt image view window with dropdown menu - select the `camera_node/image/compressed` topic.
 ```
 
+### How to save a picture from `rqt_image_view`
+
+On the top right of the `rqt_image_view` window, there is a button to save the current frame to an image. But don't save it yet. A little extra setup is needed to be able to view that file later.
+
+Create a folder on you laptop for where you would like to have the image saved to, say `~/duckiebot_images/`. Then, launch the `start_gui_tools` with the following command:
+
+```
+dts start_gui_tools --mount ~/duckiebot_images/:/duckiebot_images [DUCKIEBOT_NAME]
+```
+
+Then, run `rqt_image_view` again, and use the top-right "**Save as image**" button to save to the `/duckiebot_images` folder. To find that folder, you might need to navigate to `Computer` and select `/` directory in the pop-up dialogue.
+
+```{image} ../../_images/operations/rqt_image_view_save_btn.png
+:align: center
+:name: rqt_save_btn
+```
+
+<br/>
+
+```{image} ../../_images/operations/rqt_image_view_save_dialog1.png
+:align: center
+:name: rqt_save_dialog1
+```
+
+<br/>
+
+```{image} ../../_images/operations/rqt_image_view_save_dialog2.png
+:align: center
+:name: rqt_save_dialog2
+```
+
+<br/>
+
+And the saved image from your robot's view should appear in the folder you created!
+
 (image-dashboard)=
 ## Viewing the image stream on the Dashboard
 


### PR DESCRIPTION
Add instructions to mount folder in `start_gui_tools` and how to save an image.

![image](https://github.com/duckietown/book-opmanual-duckiebot/assets/10885835/7d6b6973-0b57-4c8c-b107-0e50147248ec)
